### PR TITLE
Add attract mode

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -161,10 +161,10 @@
             <script type="text/template" class="template">
               <% for ( var idx in rc.games) { var game = rc.games[idx]; %>
                 <section data-name='<%= game.slug %>'>
-                  <section class='autoslide-1000'>
+                  <section class='autoslide-5000'>
                     <img src='games/<%- game.slug+"/"+game.images[0] %>' />
                   </section>
-                  <section class='autoslide-1000'>
+                  <section class='autoslide-5000'>
                     <h1>
                       <%= game.name %>
                     </h1>

--- a/source/index.html
+++ b/source/index.html
@@ -160,8 +160,8 @@
         <div class="slides">
             <script type="text/template" class="template">
               <% for ( var idx in rc.games) { var game = rc.games[idx]; %>
-                <section class='game autoslide-1000' data-name='<%= game.slug %>'>
-                  <section>
+                <section data-name='<%= game.slug %>'>
+                  <section class='autoslide-1000'>
                     <img src='games/<%- game.slug+"/"+game.images[0] %>' />
                   </section>
                   <section class='autoslide-1000'>

--- a/source/index.html
+++ b/source/index.html
@@ -160,11 +160,11 @@
         <div class="slides">
             <script type="text/template" class="template">
               <% for ( var idx in rc.games) { var game = rc.games[idx]; %>
-                <section class='game' data-name='<%= game.slug %>'>
+                <section class='game autoslide-1000' data-name='<%= game.slug %>'>
                   <section>
                     <img src='games/<%- game.slug+"/"+game.images[0] %>' />
                   </section>
-                  <section>
+                  <section class='autoslide-1000'>
                     <h1>
                       <%= game.name %>
                     </h1>

--- a/source/index.html
+++ b/source/index.html
@@ -170,8 +170,8 @@
         <div class="slides">
             <script type="text/template" class="template">
               <% _.each( rc.games, function( game ){ %>
-                <section class='game' data-name='<%= game.slug %>' data-background='games/<%- game.slug+"/"+game.images.main %>'>
-                  <h2><%= game.name %></h2>
+                <section class='game' data-name='<%= game.slug %>'>
+                  <h2><img src='games/<%- game.slug+"/"+game.images.main %>'></h2>
                 </section>
               <% }); %>
             </script>

--- a/source/lib/moonshot.js
+++ b/source/lib/moonshot.js
@@ -67,7 +67,7 @@
         win.window.clearTimeout(this._attractTimer);
         this._attractTimer = win.window.setTimeout(
           function() {self.setAttractMode(true);}
-          , 10000);
+          , 30000);
       }
       // if we want to enable or
       if (enable || this._attractMode) {

--- a/source/lib/moonshot.js
+++ b/source/lib/moonshot.js
@@ -54,7 +54,7 @@
         ,height: window.innerHeight
         ,loop: true
         ,keyboard: false
-        ,transition: 'cube'
+        ,transition: 'linear'
         ,autoSlide: 0
       });
       this.setupInputs();

--- a/source/lib/moonshot.js
+++ b/source/lib/moonshot.js
@@ -28,6 +28,7 @@
     $( '.slides' ).append(
       template( templateData )
     );
+    $('.slides script').remove();
     this.games = games;
   };
 
@@ -53,17 +54,38 @@
         ,height: window.innerHeight
         ,loop: true
         ,keyboard: false
-        ,autoslide: 1000
         ,transition: 'cube'
+        ,autoSlide: 0
       });
       this.setupInputs();
       this._setFont();
+      this.setAttractMode(true);
     }
-
+    ,setAttractMode: function(enable) {
+      var self = this;
+      if(!enable) {
+        win.window.clearTimeout(this._attractTimer);
+        this._attractTimer = win.window.setTimeout(
+          function() {self.setAttractMode(true);}
+          , 10000);
+      }
+      // if we want to enable or
+      if (enable || this._attractMode) {
+        $('[class*="autoslide"]').each(function(i, slide) {
+          var delay = enable ? slide.className.match(/autoslide-(\d+)/)[1] : 0;
+          slide.setAttribute('data-autoslide', delay);
+          console.log('setting to '+delay);
+        });
+        this._attractMode = !this._attractMode ? 1 : 0;
+        this._gallery.configure({ autoSlide: this._attractMode });
+        console.log('set attract mode to '+this._attractMode);
+      }
+    }
     ,setupInputs: function() {
       var input = this._input;
 
       input.on('button_down', _.bind(function(button, padnum) {
+        this.setAttractMode(false);
         switch(button) {
           case 'button1':
           case 'action':


### PR DESCRIPTION
Slide delay is determined by class `autoslide-<number>`, which is added as `data-autoslide` attribute when attract mode engages. Moonshot strips the `data-` this because Reveal doesn't like to stop and start on command. This probably fixes #1 for the immediate future.
