### PR TITLE
Restore child process exit behavior

### DIFF
--- a/games/akbb/lexitron.json
+++ b/games/akbb/lexitron.json
@@ -32,7 +32,7 @@
 		}
 	],
 
-	"exec": "akbb/bin/ASBB_13_11_18.exe",
+	"exec": "akbb/bin/AKBB_13_11_18.exe",
 	"args": "",
 	"cwd": "akbb/bin/"
 

--- a/source/lib/moonshot.js
+++ b/source/lib/moonshot.js
@@ -234,22 +234,9 @@
         }
         console.log('Child Process STDOUT: '+stdout);
         console.log('Child Process STDERR: '+stderr);
+        this.endGame();
       }, this)).pid;
-      this.checkForGameEnd();
     }, 5000, {trailing: false})
-    ,checkForGameEnd: function() {
-      var self = this
-      ,game = self._cp.spawn('wmic', ['process', self._gamePid]);
-
-      game.stderr.on('data', function (data) {
-        if(data.toString().indexOf('No Instance(s) Available.') != -1) {
-          self.endGame();
-        }
-      });
-      if(this._gamePid !== undefined) {
-        setTimeout(function(){self.checkForGameEnd.call(self)}, 200);
-      }
-    }
     ,_nextFont: function() {
       // TODO: not working.
       this._fontIndex--;


### PR DESCRIPTION
The Node.js `ChildProcess.exec` callback gets called after the
child process exits. This change moves the "on exit" code inside the
callback and removes the polling behavior. Seems to be working on the
Lexitron. Fixes transient failure to remove the loading screen.
